### PR TITLE
Drop test-dependencies

### DIFF
--- a/mini-kanren.egg
+++ b/mini-kanren.egg
@@ -5,7 +5,6 @@
  (license "MIT")
  (category logic)
  (dependencies srfi-1)
- (test-dependencies test)
  (author "William Byrd, Dan Friedman, Oleg Kiselyov")
  (maintainer "Jeremy Steward")
  (components


### PR DESCRIPTION
The egg doesn't have tests, so there's no need to specify
test-dependencies.